### PR TITLE
Support piping process IDs via standard input

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 A dotnet global tool that gracefully stops processes by sending them SIGINT (Ctrl+C) in a cross platform way.
 
 ``` bash
-dnx stop <processId> [--timeout <milliseconds>] [--quiet]
+dnx stop [<processId>] [--timeout <milliseconds>] [--quiet]
 ```
 
 <!-- include src/help.md -->
@@ -17,7 +17,7 @@ Usage: [arguments...] [options...] [-h|--help] [--version]
 Sends the SIGINT (Ctrl+C) signal to a process to gracefully stop it.
 
 Arguments:
-  [0] <int>    ID of the process to stop.
+  [0] <int?>    ID of the process to stop. When omitted, reads process IDs from standard input.
 
 Options:
   -t, --timeout <int?>    Optional timeout in milliseconds to wait for the process to exit.
@@ -29,6 +29,25 @@ Options:
 If no timeout is provided, the tool will wait indefinitely for the target process to exit.
 Otherwise, the process will exit with a non-zero exit code if the target process didn't 
 exit within the specified timeout time.
+
+## Piping from PowerShell
+
+When no process ID is given, `dnx stop` reads process IDs from standard input. This allows 
+piping directly from PowerShell's `Get-Process`:
+
+```powershell
+# Stop all processes named 'foo'
+Get-Process -Name foo | dnx stop
+
+# Stop multiple processes by name
+Get-Process -Name foo, bar | dnx stop
+```
+
+You can also pipe just the IDs:
+
+```powershell
+Get-Process -Name foo | Select-Object -ExpandProperty Id | dnx stop
+```
 
 <!-- #content -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,21 +1,102 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using ConsoleAppFramework;
 using Spectre.Console;
 
 ConsoleApp.Run(args, Stop);
 
 /// <summary>Sends the SIGINT (Ctrl+C) signal to a process to gracefully stop it.</summary>
-/// <param name="id">ID of the process to stop.</param>
+/// <param name="id">ID of the process to stop. When omitted, reads process IDs from standard input.</param>
 /// <param name="timeout">-t, Optional timeout in milliseconds to wait for the process to exit.</param>
 /// <param name="quiet">-q, Do not display any output.</param>
-static int Stop([Argument] int id, [HideDefaultValue] int? timeout = default, bool quiet = false)
+static int Stop([Argument] int? id = null, [HideDefaultValue] int? timeout = default, bool quiet = false)
 {
-    if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-        return StopWindowsProcess(id, timeout, quiet);
-    else
-        return StopUnixProcess(id, timeout, quiet);
+    if (id == null)
+    {
+        if (!Console.IsInputRedirected)
+        {
+            if (!quiet)
+                AnsiConsole.MarkupLine("[red]No process ID specified[/]");
+            return -1;
+        }
+
+        var lines = Console.In.ReadToEnd().Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        var seen = new HashSet<int>();
+        var pids = new List<int>();
+        foreach (var pid in ParsePids(lines))
+            if (seen.Add(pid))
+                pids.Add(pid);
+
+        if (pids.Count == 0)
+        {
+            if (!quiet)
+                AnsiConsole.MarkupLine("[red]No process IDs found in standard input[/]");
+            return -1;
+        }
+
+        var anyFailure = false;
+        foreach (var pid in pids)
+            if (StopProcess(pid, timeout, quiet) != 0)
+                anyFailure = true;
+
+        return anyFailure ? -1 : 0;
+    }
+
+    return StopProcess(id.Value, timeout, quiet);
+}
+
+static int StopProcess(int id, int? timeout, bool quiet) =>
+    Environment.OSVersion.Platform == PlatformID.Win32NT
+        ? StopWindowsProcess(id, timeout, quiet)
+        : StopUnixProcess(id, timeout, quiet);
+
+// Parses process IDs from stdin, supporting:
+//   - PowerShell Get-Process table format (detects "Id" column header + separator line)
+//   - Plain integers, one per line (e.g. piped via Select-Object -ExpandProperty Id)
+static IEnumerable<int> ParsePids(string[] lines)
+{
+    // Detect table format: a line containing whole-word "Id" followed by a separator line (dashes/spaces)
+    var idRightEdge = -1;
+    var dataStartLine = 0;
+
+    for (var i = 0; i < lines.Length; i++)
+    {
+        var idMatch = Regex.Match(lines[i], @"\bId\b");
+        if (idMatch.Success && i + 1 < lines.Length && Regex.IsMatch(lines[i + 1], @"^[\s\-]+$"))
+        {
+            // Right edge of "Id" aligns with the right edge of PID values (right-aligned column)
+            idRightEdge = idMatch.Index + 1;
+            dataStartLine = i + 2;
+            break;
+        }
+    }
+
+    if (idRightEdge >= 0)
+    {
+        for (var i = dataStartLine; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (line.Length <= idRightEdge) continue;
+
+            // Scan backward from the right edge of the Id column to extract the integer
+            var end = idRightEdge;
+            while (end >= 0 && char.IsWhiteSpace(line[end])) end--;
+            var start = end;
+            while (start > 0 && char.IsDigit(line[start - 1])) start--;
+
+            if (end >= start && end >= 0 && int.TryParse(line.AsSpan(start, end - start + 1), out var pid))
+                yield return pid;
+        }
+        yield break;
+    }
+
+    // Plain integer fallback: one PID per line
+    foreach (var line in lines)
+        if (int.TryParse(line.Trim(), out var pid))
+            yield return pid;
 }
 
 static int StopUnixProcess(int id, int? timeout, bool quiet)

--- a/src/help.md
+++ b/src/help.md
@@ -4,7 +4,7 @@ Usage: [arguments...] [options...] [-h|--help] [--version]
 Sends the SIGINT (Ctrl+C) signal to a process to gracefully stop it.
 
 Arguments:
-  [0] <int>    ID of the process to stop.
+  [0] <int?>    ID of the process to stop. When omitted, reads process IDs from standard input.
 
 Options:
   -t, --timeout <int?>    Optional timeout in milliseconds to wait for the process to exit.


### PR DESCRIPTION
Allow usage like \Get-Process -Name foo | dnx stop\ in addition to the existing \dnx stop <id>\ invocation.

When no process ID argument is provided, the tool reads PIDs from stdin, supporting two formats:
- PowerShell \Get-Process\ table output (detects \Id\ column by header/separator)
- Plain integers, one per line (e.g. from \Select-Object -ExpandProperty Id\)

Multiple PIDs are deduplicated and stopped sequentially. Exit code is non-zero if any stop operation fails.