### PR TITLE
Strip symbols when publishing AOT

### DIFF
--- a/src/dotnet-stop.csproj
+++ b/src/dotnet-stop.csproj
@@ -25,6 +25,7 @@
   <PropertyGroup Condition="'$(HybridToolPackage)' == 'true'">
     <ToolPackageRuntimeIdentifiers>win-x64;linux-x64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
     <PublishAot>true</PublishAot>
+    <StripSymbols>true</StripSymbols>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This decreases the package size.