### PR TITLE
Add support for more RIDs and simplify packaging logic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,14 @@ jobs:
         include:
           - os: ubuntu-latest
             rid: linux-x64
+          - os: ubuntu-24.04-arm
+            rid: linux-arm64
           - os: windows-latest
             rid: win-x64
+          - os: windows-11-arm
+            rid: win-arm64
+          - os: macos-15-intel
+            rid: osx-x64
           - os: macos-latest
             rid: osx-arm64
     steps:
@@ -41,13 +47,14 @@ jobs:
         uses: devlooped/actions-dotnet-env@v1
 
       - name: 📦 pack
-        run: dotnet pack src/dotnet-stop.csproj -c $env:Configuration -r ${{ matrix.rid }} -p:HybridToolPackage=true -bl:"pack-${{ matrix.rid }}.binlog"
+        run: dotnet pack src/dotnet-stop.csproj -c $env:Configuration -r ${{ matrix.rid }} -bl:"pack-${{ matrix.rid }}.binlog"
 
       - name: 📤 package
         uses: actions/upload-artifact@v4
         with:
           name: package-${{ matrix.rid }}
           path: bin/*.${{ matrix.rid }}.*.nupkg
+          retention-days: 30
           if-no-files-found: error
 
       - name: 🐛 logs
@@ -80,10 +87,10 @@ jobs:
         run: dnx --yes retest -- --no-build
 
       - name: 📦 pointer
-        run: dotnet pack src/dotnet-stop.csproj -c $env:Configuration -p:HybridToolPackage=true -bl:pointer-pack.binlog
+        run: dotnet pack src/dotnet-stop.csproj -c $env:Configuration -bl:pointer-pack.binlog
 
       - name: 📦 fallback
-        run: dotnet pack src/dotnet-stop.csproj -c $env:Configuration -r any -p:HybridToolPackage=true -p:PublishAot=false -bl:any-pack.binlog
+        run: dotnet pack src/dotnet-stop.csproj -c $env:Configuration -r any -bl:any-pack.binlog
 
       - name: 📥 packages
         uses: actions/download-artifact@v4
@@ -103,7 +110,7 @@ jobs:
         if: ${{ env.NUGET_API_KEY != '' && github.event.action != 'prereleased' }}
         run: |
           $packages = @(Get-ChildItem bin -Filter *.nupkg | Where-Object Name -NotLike '*.symbols.nupkg' | Sort-Object Name)
-          $runtimePackagePattern = '^stop\.(win-x64|linux-x64|osx-arm64|any)\..+\.nupkg$'
+          $runtimePackagePattern = '^stop\.(win-x64|win-arm64|linux-x64|linux-arm64|osx-x64|osx-arm64|any)\..+\.nupkg$'
           $runtimePackages = @($packages | Where-Object Name -Match $runtimePackagePattern)
           $pointerPackages = @($packages | Where-Object Name -NotMatch $runtimePackagePattern)
 
@@ -122,7 +129,7 @@ jobs:
         if: env.SLEET_CONNECTION != ''
         run: |
           $packages = @(Get-ChildItem bin -Filter *.nupkg | Where-Object Name -NotLike '*.symbols.nupkg' | Sort-Object Name)
-          $runtimePackagePattern = '^stop\.(win-x64|linux-x64|osx-arm64|any)\..+\.nupkg$'
+          $runtimePackagePattern = '^stop\.(win-x64|win-arm64|linux-x64|linux-arm64|osx-x64|osx-arm64|any)\..+\.nupkg$'
           $runtimePackages = @($packages | Where-Object Name -Match $runtimePackagePattern)
           $pointerPackages = @($packages | Where-Object Name -NotMatch $runtimePackagePattern)
 

--- a/src/dotnet-stop.csproj
+++ b/src/dotnet-stop.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Devlooped</RootNamespace>
     <SignAssembly>false</SignAssembly>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 
     <Description>A dotnet global tool that gracefully stops processes by sending them SIGINT (Ctrl+C) in a cross platform way.</Description>
     <PackageId>stop</PackageId>
@@ -17,15 +18,18 @@
     <PackageProjectUrl>https://clarius.org/dotnet-stop</PackageProjectUrl>
 
     <!-- Allow running on whatever latest version users have. See https://docs.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward -->
+    <!-- Useful for RID=any -->
     <RollForward>LatestMajor</RollForward>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64;any</RuntimeIdentifiers>
 
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(HybridToolPackage)' == 'true'">
-    <ToolPackageRuntimeIdentifiers>win-x64;linux-x64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
     <PublishAot>true</PublishAot>
     <StripSymbols>true</StripSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'any'">
+    <PublishAot>false</PublishAot>
+    <PublishSelfContained>true</PublishSelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Expanded publish matrix and .csproj to support win-arm64, linux-arm64, osx-x64, and windows-11-arm. Removed HybridToolPackage logic and ToolPackageRuntimeIdentifiers. Updated NuGet/Sleet steps to match new RIDs. Added special handling for RID=any in .csproj.