### PR TITLE
Fix ConPTY TUI shutdown and split --debug from debugger attach.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,8 @@ Arguments:
 Options:
   -t, --timeout <int?>    Optional timeout in milliseconds to wait for the process to exit.
   -q, --quiet             Do not display any output.
-  -d, --debug             Debug the process stopping operation.
+      --attach            Attach a .NET debugger before stopping.
+  -d, --debug             Print diagnostic details about the stop operation.
 ```
 
 <!-- src/stop/help.md -->

--- a/src/stop/Program.cs
+++ b/src/stop/Program.cs
@@ -14,10 +14,11 @@ ConsoleApp.Run(args, Stop);
 /// <param name="id">ID of the process to stop. When omitted, reads process IDs from standard input.</param>
 /// <param name="timeout">-t, Optional timeout in milliseconds to wait for the process to exit.</param>
 /// <param name="quiet">-q, Do not display any output.</param>
-/// <param name="debug">-d, Debug the process stopping operation.</param>
-static int Stop([Argument] int? id = null, [HideDefaultValue] int? timeout = default, bool quiet = false, bool debug = false)
+/// <param name="debug">-d, Print diagnostic details about the stop operation.</param>
+/// <param name="attach">Attach a .NET debugger before stopping.</param>
+static int Stop([Argument] int? id = null, [HideDefaultValue] int? timeout = default, bool quiet = false, bool debug = false, bool attach = false)
 {
-    if (debug)
+    if (attach)
         Debugger.Launch();
 
     if (id == null)

--- a/src/stop/help.md
+++ b/src/stop/help.md
@@ -9,5 +9,6 @@ Arguments:
 Options:
   -t, --timeout <int?>    Optional timeout in milliseconds to wait for the process to exit.
   -q, --quiet             Do not display any output.
-  -d, --debug             Debug the process stopping operation.
+  -d, --debug             Print diagnostic details about the stop operation.
+  --attach                Attach a .NET debugger before stopping.
 ```

--- a/src/stop/readme.md
+++ b/src/stop/readme.md
@@ -24,7 +24,8 @@ Arguments:
 Options:
   -t, --timeout <int?>    Optional timeout in milliseconds to wait for the process to exit.
   -q, --quiet             Do not display any output.
-  -d, --debug             Debug the process stopping operation.
+      --attach            Attach a .NET debugger before stopping.
+  -d, --debug             Print diagnostic details about the stop operation.
 ```
 
 <!-- src/stop/help.md -->

--- a/src/stopr/NativeMethods.cs
+++ b/src/stopr/NativeMethods.cs
@@ -6,6 +6,8 @@ namespace Devlooped;
 static class NativeMethods
 {
     public const uint CtrlCEvent = 0;
+    public const uint Th32CsSnapProcess = 0x00000002;
+    public const uint InvalidHandleValue = unchecked((uint)-1);
 
     public delegate bool ConsoleCtrlHandler(uint ctrlType);
 
@@ -20,4 +22,30 @@ static class NativeMethods
 
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern bool SetConsoleCtrlHandler(ConsoleCtrlHandler? handler, bool add);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern nint CreateToolhelp32Snapshot(uint dwFlags, uint th32ProcessID);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool Process32First(nint hSnapshot, ref ProcessEntry32 lppe);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool Process32Next(nint hSnapshot, ref ProcessEntry32 lppe);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct ProcessEntry32
+    {
+        public uint dwSize;
+        public uint cntUsage;
+        public uint th32ProcessID;
+        public nint th32DefaultHeapID;
+        public uint th32ModuleID;
+        public uint cntThreads;
+        public uint th32ParentProcessID;
+        public int pcPriClassBase;
+        public uint dwFlags;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+        public string szExeFile;
+    }
 }

--- a/src/stopr/Program.cs
+++ b/src/stopr/Program.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Devlooped;
 
 if (!OperatingSystem.IsWindows())
@@ -7,17 +8,77 @@ if (args.Length != 1 || !int.TryParse(args[0], out var pid))
     return 2;
 
 NativeMethods.FreeConsole();
-if (!NativeMethods.AttachConsole((uint)pid))
+if (!TryAttachConsoleChain((uint)pid, out var attachedDirectly))
     return 1;
 
 NativeMethods.SetConsoleCtrlHandler(null, true);
-if (!NativeMethods.GenerateConsoleCtrlEvent(NativeMethods.CtrlCEvent, 0))
+try
+{
+    var processGroupId = attachedDirectly ? 0u : (uint)pid;
+    if (!SendCtrlC(processGroupId))
+        return 3;
+
+    Thread.Sleep(300);
+
+    SendCtrlC(processGroupId);
+    return 0;
+}
+finally
 {
     NativeMethods.FreeConsole();
     NativeMethods.SetConsoleCtrlHandler(null, false);
-    return 3;
 }
 
-NativeMethods.FreeConsole();
-NativeMethods.SetConsoleCtrlHandler(null, false);
-return 0;
+static bool TryAttachConsoleChain(uint pid, out bool attachedDirectly)
+{
+    if (NativeMethods.AttachConsole(pid))
+    {
+        attachedDirectly = true;
+        return true;
+    }
+
+    for (var current = GetParentProcessId(pid); current != 0; current = GetParentProcessId(current))
+    {
+        if (NativeMethods.AttachConsole(current))
+        {
+            attachedDirectly = false;
+            return true;
+        }
+    }
+
+    attachedDirectly = false;
+    return false;
+}
+
+static uint GetParentProcessId(uint pid)
+{
+    var snapshot = NativeMethods.CreateToolhelp32Snapshot(NativeMethods.Th32CsSnapProcess, 0);
+    if (snapshot == (nint)(-1))
+        return 0;
+
+    try
+    {
+        var entry = new NativeMethods.ProcessEntry32 { dwSize = (uint)Marshal.SizeOf<NativeMethods.ProcessEntry32>() };
+        if (!NativeMethods.Process32First(snapshot, ref entry))
+            return 0;
+
+        do
+        {
+            if (entry.th32ProcessID == pid)
+                return entry.th32ParentProcessID;
+        }
+        while (NativeMethods.Process32Next(snapshot, ref entry));
+    }
+    finally
+    {
+        CloseHandle(snapshot);
+    }
+
+    return 0;
+}
+
+static bool SendCtrlC(uint processGroupId) =>
+    NativeMethods.GenerateConsoleCtrlEvent(NativeMethods.CtrlCEvent, processGroupId);
+
+[DllImport("kernel32.dll", SetLastError = true)]
+static extern bool CloseHandle(nint hObject);


### PR DESCRIPTION
Walk the parent process chain in stopr when AttachConsole fails on ConPTY apps like grok, send double Ctrl+C with the right process group for each attach path, and use --attach for Debugger.Launch while --debug prints diagnostics.