### PR TITLE
Bundle stopr in CI any packages and fix Windows console shutdown detection

### DIFF
--- a/src/stop/Program.cs
+++ b/src/stop/Program.cs
@@ -166,13 +166,22 @@ static int StopWindowsProcess(int id, int? timeout, bool quiet, bool debug)
     if (debug)
         AnsiConsole.MarkupLine($"[grey]stopr exit code = {stoprExit}[/]");
 
-    if (stoprExit != 0)
+    if (!IsStoprSuccess(stoprExit))
     {
         if (debug)
             AnsiConsole.MarkupLine("[grey]Using GUI (WM_CLOSE) shutdown path[/]");
 
         if (!SendCloseToGuiProcess(process, debug))
         {
+            process.Refresh();
+            if (process.HasExited)
+            {
+                if (debug)
+                    AnsiConsole.MarkupLine("[grey]Target process already exited after stopr[/]");
+
+                return 0;
+            }
+
             if (!quiet)
                 AnsiConsole.MarkupLine($"[red]No closeable windows found for process {process.ProcessName}:{process.Id}[/]");
 
@@ -181,7 +190,10 @@ static int StopWindowsProcess(int id, int? timeout, bool quiet, bool debug)
     }
     else if (debug)
     {
-        AnsiConsole.MarkupLine("[grey]Using console (Ctrl+C) shutdown path via stopr[/]");
+        if (stoprExit == 0)
+            AnsiConsole.MarkupLine("[grey]Using console (Ctrl+C) shutdown path via stopr[/]");
+        else
+            AnsiConsole.MarkupLine("[grey]stopr posted Ctrl+C (exit code indicates signal was delivered)[/]");
     }
 
     if (timeout != null)
@@ -221,6 +233,10 @@ static int RunStopr(int pid, bool debug)
     }
 }
 
+// stopr may exit with STATUS_CONTROL_C_EXIT after successfully posting Ctrl+C.
+static bool IsStoprSuccess(int exitCode) =>
+    exitCode == 0 || unchecked((int)0xC000013A) == exitCode;
+
 static ProcessStartInfo CreateStoprStartInfo(int pid)
 {
     var dir = AppContext.BaseDirectory;
@@ -235,6 +251,9 @@ static ProcessStartInfo CreateStoprStartInfo(int pid)
     }
 
     var stoprDll = Path.Combine(dir, "stopr.dll");
+    if (!File.Exists(stoprDll))
+        throw new FileNotFoundException($"stopr helper was not found next to {dir}.", stoprDll);
+
     var host = Environment.ProcessPath ?? "dotnet";
     return new ProcessStartInfo(host, $"exec \"{stoprDll}\" {pid}")
     {

--- a/src/stop/stop.csproj
+++ b/src/stop/stop.csproj
@@ -43,19 +43,30 @@
 
   <Target Name="BundleStoprForBuild"
           AfterTargets="Build"
+          BeforeTargets="_GetTfmSpecificContentForPackage"
           Condition="'$(DesignTimeBuild)' != 'true'">
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\stopr\stopr.csproj"
              Targets="Build"
-             Properties="Configuration=$(Configuration)" />
+             Properties="Configuration=$(Configuration);RuntimeIdentifier=$(RuntimeIdentifier)" />
 
     <ItemGroup>
-      <_StoprBuildOutput Include="$(MSBuildThisFileDirectory)..\stopr\bin\$(Configuration)\$(TargetFramework)\stopr.*" />
+      <_StoprBuildOutput Include="$(MSBuildThisFileDirectory)..\stopr\bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\stopr.*"
+                         Condition="'$(RuntimeIdentifier)' != ''" />
+      <_StoprBuildOutput Include="$(MSBuildThisFileDirectory)..\stopr\bin\$(Configuration)\$(TargetFramework)\stopr.*"
+                         Condition="'$(RuntimeIdentifier)' == ''" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_StoprBuildOutput)"
           DestinationFolder="$(OutputPath)"
           SkipUnchangedFiles="true"
-          Condition="Exists('$(MSBuildThisFileDirectory)..\stopr\bin\$(Configuration)\$(TargetFramework)')" />
+          Condition="@(_StoprBuildOutput->Count()) != 0" />
+
+    <ItemGroup Condition="'$(PackAsTool)' == 'true' and '$(RuntimeIdentifier)' != ''">
+      <TfmSpecificPackageFile Include="$(OutputPath)stopr.deps.json" PackagePath="tools/$(TargetFramework)/any" />
+      <TfmSpecificPackageFile Include="$(OutputPath)stopr.dll" PackagePath="tools/$(TargetFramework)/any" />
+      <TfmSpecificPackageFile Include="$(OutputPath)stopr.runtimeconfig.json" PackagePath="tools/$(TargetFramework)/any" />
+      <TfmSpecificPackageFile Include="$(OutputPath)stopr.exe" PackagePath="tools/$(TargetFramework)/any" Condition="Exists('$(OutputPath)stopr.exe')" />
+    </ItemGroup>
   </Target>
 
   <Target Name="BundleStoprForPack"

--- a/src/stopr/Program.cs
+++ b/src/stopr/Program.cs
@@ -11,22 +11,21 @@ NativeMethods.FreeConsole();
 if (!TryAttachConsoleChain((uint)pid, out var attachedDirectly))
     return 1;
 
-NativeMethods.SetConsoleCtrlHandler(null, true);
+NativeMethods.SetConsoleCtrlHandler(IgnoreCtrlHandler, true);
 try
 {
-    var processGroupId = attachedDirectly ? 0u : (uint)pid;
-    if (!SendCtrlC(processGroupId))
+    if (!SendCtrlCToTarget(attachedDirectly, (uint)pid))
         return 3;
 
     Thread.Sleep(300);
 
-    SendCtrlC(processGroupId);
+    SendCtrlCToTarget(attachedDirectly, (uint)pid);
     return 0;
 }
 finally
 {
     NativeMethods.FreeConsole();
-    NativeMethods.SetConsoleCtrlHandler(null, false);
+    NativeMethods.SetConsoleCtrlHandler(IgnoreCtrlHandler, false);
 }
 
 static bool TryAttachConsoleChain(uint pid, out bool attachedDirectly)
@@ -79,6 +78,11 @@ static uint GetParentProcessId(uint pid)
 
 static bool SendCtrlC(uint processGroupId) =>
     NativeMethods.GenerateConsoleCtrlEvent(NativeMethods.CtrlCEvent, processGroupId);
+
+static bool SendCtrlCToTarget(bool attachedDirectly, uint pid) =>
+    attachedDirectly ? SendCtrlC(0) : SendCtrlC(pid) || SendCtrlC(0);
+
+static bool IgnoreCtrlHandler(uint ctrlType) => true;
 
 [DllImport("kernel32.dll", SetLastError = true)]
 static extern bool CloseHandle(nint hObject);


### PR DESCRIPTION
Published stop.any builds were missing stopr, so dnx fell back to a failing dotnet exec path; treat stopr's STATUS_CONTROL_C_EXIT as success and improve ConPTY parent-chain Ctrl+C delivery.