### PR TITLE
Fix RID tool packages by bundling stopr only in stop.any

### DIFF
--- a/src/stop/stop.csproj
+++ b/src/stop/stop.csproj
@@ -61,7 +61,7 @@
           SkipUnchangedFiles="true"
           Condition="@(_StoprBuildOutput->Count()) != 0" />
 
-    <ItemGroup Condition="'$(PackAsTool)' == 'true' and '$(RuntimeIdentifier)' != ''">
+    <ItemGroup Condition="'$(PackAsTool)' == 'true' and '$(RuntimeIdentifier)' == 'any'">
       <TfmSpecificPackageFile Include="$(OutputPath)stopr.deps.json" PackagePath="tools/$(TargetFramework)/any" />
       <TfmSpecificPackageFile Include="$(OutputPath)stopr.dll" PackagePath="tools/$(TargetFramework)/any" />
       <TfmSpecificPackageFile Include="$(OutputPath)stopr.runtimeconfig.json" PackagePath="tools/$(TargetFramework)/any" />


### PR DESCRIPTION
## Summary
- Limit `stopr` TfmSpecificPackageFile bundling to the `any` fallback package only.
- Prevents native AOT RID packages from adding stray `tools/net10.0/any/stopr.*` files that break `dnx`/`dotnet tool` resolution of `DotnetToolSettings.xml`.

## Test plan
- [x] Rebuilt `stop.win-x64` locally and confirmed package layout matches 2.0.1 (no `tools/net10.0/any/stopr.*`).
- [x] Verified `stop.any` still includes `stopr` at `tools/net10.0/any/`.
- [x] Ran `dnx -y stop --version 42.42.42 --source <local-feed> -- --version` successfully.
